### PR TITLE
TypoFix - version name from Zodaic to Zodiac

### DIFF
--- a/contracts/OZGovernorModule.sol
+++ b/contracts/OZGovernorModule.sol
@@ -157,7 +157,7 @@ contract OZGovernorModule is
 
     /// @dev Returns this module's version.
     function version() public pure override returns (string memory) {
-        return "Zodaic OZ Governor Module: v1.0.0";
+        return "Zodiac OZ Governor Module: v1.0.0";
     }
 
     /// The following functions are overrides required by Solidity.


### PR DESCRIPTION
The version() function was returning "Zodaic...", fixed the typo to "Zodiac...".